### PR TITLE
Fix thdid bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib_composite"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Gregor Peach <gregorpeach@gmail.com>"]
 license = "MIT"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 // We kinda need to run on nightly to make xargo work
 // However, it would be nice to avoid having to depend on unstable features
-// TODO: Investigate the stabilization of "shared"
-#![feature(shared)]
 // TODO: Investigate switching to marker types
 #![feature(optin_builtin_traits)]
 // TODO: Remove uses of FnBox once Box<FnOnce()> just works

--- a/src/sl.rs
+++ b/src/sl.rs
@@ -94,7 +94,7 @@ impl Sl {
 
     pub fn spawn<F: FnBox(Sl)>(&self, entrypoint: F) -> Thread {
         let boxed_fn = Box::new(FnBoxWrapper {
-            inner: Box::new(entrypoint) 
+            inner: Box::new(entrypoint)
         });
 
         unsafe {

--- a/src/sys/types.rs
+++ b/src/sys/types.rs
@@ -12,8 +12,10 @@ pub type thdid_t = c_ushort;
 pub type vaddr_t = c_ulong;
 
 // Capability types
+pub type tcap_res_t = c_ulong;
 pub type capid_t = c_ulong;
 pub type tcap_t = capid_t;
 pub type thdcap_t = capid_t;
 pub type arcvcap_t = capid_t;
 pub type pgtblcap_t = capid_t;
+pub type asndcap_t = capid_t;


### PR DESCRIPTION
Fixed issue with the definition of sl_thd in rust that was causing the thread
id to get lost. Changed sl_thd to match c definition and added necessary
composite types. Changed sl::Thread to just contain the thread id and changed
sl functions that previously reference the thd_ptr to now just use the thdid or
directly calling out to sl.